### PR TITLE
Fix spelling and grammar in section 3, dev ops

### DIFF
--- a/helix/devops/deployment/what-to-deploy.rst
+++ b/helix/devops/deployment/what-to-deploy.rst
@@ -101,7 +101,7 @@ Once you have mapped the ownership and direction of data in your
 implementation, avoid making changes that violate this, for example by
 submitting code or configuration changes directly to test or product
 environments and circumventing the QA and development procedures.
-Violating this mapping is highly discouraged and should be avoided as
+Violating this mapping is highly discouraged and should be avoided at
 all cost.
 
 Consider every type of deployment onto the environments, including

--- a/helix/devops/deployment/what-to-deploy.rst
+++ b/helix/devops/deployment/what-to-deploy.rst
@@ -77,7 +77,7 @@ Files
         Environment
             :What is it: Configuration file changes relating to the specific running server or specific environment, for example connection strings, server names, domains etc.
             :Owned by: Deployment    
-            :Direction: Set up by the deployment and managed in the specific environments.|
+            :Direction: Set up by the deployment and managed in the specific environments.
 
 Environment    
     :What is it: The infrastructure needed for running the Sitecore and the application. 
@@ -85,17 +85,17 @@ Environment
     Configuration    
         :What is it: Server or environment specific configurations such as network, DNS, hosts file changes, machine.config etc. 
         :Owned by: Deployment    
-        :Direction: Set up as part of the initial deployment process. Can be automated but often is not.|
+        :Direction: Set up as part of the initial deployment process. Can be automated but often is not.
 
     Services   
         :What is it: Related services running in the environment or on the instance server, for example operating systems, IIS, SQL servers, Windows Services etc.   
         :Owned by: Deployment    
-        :Direction: Set up as part of the initial deployment process. Can be automated but often is not.|
+        :Direction: Set up as part of the initial deployment process. Can be automated but often is not.
 
     Infrastructure   
         :What is it: The underlying server, virtual or physical,     
         :Owned by: Deployment    
-        :Direction: Set up as part of the initial deployment process. Can be automated but often is not.|
+        :Direction: Set up as part of the initial deployment process. Can be automated but often is not.
 
 Once you have mapped the ownership and direction of data in your
 implementation, avoid making changes that violate this, for example by

--- a/helix/devops/development/local-deployment.rst
+++ b/helix/devops/development/local-deployment.rst
@@ -18,7 +18,7 @@ implementation specific files are physically separated from the files in
 the standard frameworks etc. On the other hand, tools and processes
 might cater for this separation, even when working inside the web root.
 
-Generally, if tasks that are repeated frequently becomes taxing, they
+Generally, if tasks that are repeated frequently become taxing, they
 will be circumvented – and this will lead to inconsistencies in the
 processes and ultimately inconsistencies in quality. Therefore,
 secondly, the ease of development is important. Working outside the web

--- a/helix/devops/development/setting-up.rst
+++ b/helix/devops/development/setting-up.rst
@@ -30,7 +30,7 @@ Check out
 Dependencies
     Import and configure external frameworks and dependencies
     
-    *For example: Execute package managers such as NuGet or npm or runs custom scripts to restore required dependencies*
+    *For example: Execute package managers such as NuGet or npm or run custom scripts to restore required dependencies*
 
 Build
     Compile the modules


### PR DESCRIPTION
While reading through the Helix documentation I found these issues in the Dev Ops section.