### PR TITLE
Language fixes in section 2

### DIFF
--- a/helix/principles/architecture-principles/dependencies.rst
+++ b/helix/principles/architecture-principles/dependencies.rst
@@ -55,7 +55,7 @@ Types of dependencies
 ^^^^^^^^^^^^^^^^^^^^^
 
 In software, dependencies can either be explicit or implicit. Examples
-of explicit dependencies are the keyword using in C#, and a reference in
+of explicit dependencies are the keyword :code:`using` in C#, and a reference in
 one assembly to another. Examples of implicit dependencies are a class
 string in the HTML mark-up, references to Sitecore fields by name or
 reliance on specific technology behaviours in one module without
@@ -64,7 +64,7 @@ interface of the module.
 
 It is very important to stress that conceptually, as well as
 practically, all dependencies between modules count. In a Sitecore
-context this, includes not only references between C# classes and .NET
+context this includes not only references between C# classes and .NET
 assemblies, but also references from code to Sitecore templates and
 fields, references between templates, references from templates to
 renderings, references from HTML mark-up to CSS and so on. Therefore,

--- a/helix/principles/architecture-principles/domain-language.rst
+++ b/helix/principles/architecture-principles/domain-language.rst
@@ -11,7 +11,7 @@ users, editors, administrators or visitors. Therefore, establishing a
 common domain language between the developers and business users should
 be a top priority in any project. Likewise, once a domain language has
 been established, it is imperative that the terminology be ubiquitous.
-What is even worse and more confusing than using the wrong terminology,
+What is even worse and more confusing than using the wrong terminology
 is using multiple terminologies at once.
 
 .. admonition:: Habitat Example

--- a/helix/principles/architecture-principles/layers.rst
+++ b/helix/principles/architecture-principles/layers.rst
@@ -14,7 +14,7 @@ in terms of dependency direction.
 
 Even though layers are a conceptual construct in the architecture,
 layers are physically described in the implementation by folders in the
-filesystem, Visual Studio and Sitecore along with namespaces in code and
+filesystem, Visual Studio and Sitecore, along with namespaces in code and
 layers defines in which direction modules can depend on other modules.
 
 Layers helps control the direction of dependencies – the importance of
@@ -117,8 +117,8 @@ thus, remembering the Stable Dependency Principle, should have the
 fewest dependencies on it.
 
 The Project layer is typically small and contains few modules, often
-determined by the number of tenants in the solution and their needs (See
-see :doc:`/principles/multi-site/index`).
+determined by the number of tenants in the solution and their needs (see
+:doc:`/principles/multi-site/index`).
 
 Typically, in a single tenant solution there will only be a single
 module, namely the specific website or requirements that fits the needs
@@ -147,7 +147,7 @@ Feature Layer
 
 The *Feature* layer contains concrete features of the solution as
 understood by the business owners and editors of the solution, for
-example news, articles, promotions, website search etc.
+example news, articles, promotions, website search, etc.
 
 The features are expressed as seen in the business domain of the
 solution and not by technology, which means that the responsibility of a
@@ -191,10 +191,10 @@ typical approach would be to add the concept of indexing and rendering
 search results to a foundation level module (see :doc:`/principles/architecture-principles/layers`) which the
 Search feature module then utilises. Other modules can then offer their
 content to search by plug into the indexing and rendering functionality
-in the foundation module – through for example an inversion of control
+in the Foundation module – through for example an inversion of control
 pattern.
 
-Note that although, several modules in the Feature layer can be grouped
+Note that although several modules in the Feature layer can be grouped
 together semantically (see :doc:`/principles/architecture-principles/modules`) 
 this only suggests a conceptual coherence between modules – not in any 
 way a technical dependency.
@@ -246,7 +246,7 @@ do not contain presentation in the form of renderings or views - as
 these are to be considered concrete. Some framework modules might still
 contain mark-up in code though, examples being precompiled web-controls
 and html helper functions, but in order to control dependencies, any
-feature or project specific knowledge should be passed as parameters
+Feature or Project specific knowledge should be passed as parameters
 from the depending module.
 
 .. admonition:: Habitat Example
@@ -260,7 +260,7 @@ from the depending module.
     anything about the new module or its content.
 
 Unlike the Feature layer, there is no strict convention on dependencies
-between modules in the foundation layer. This means that one Foundation
+between modules in the Foundation layer. This means that one Foundation
 layer module can depend on another Foundation layer module in the
 solution – as long as they rely on the basic principles on component
 architecture such as the Acyclic Dependencies Principle and the Stable

--- a/helix/principles/configuration/definition-scope.rst
+++ b/helix/principles/configuration/definition-scope.rst
@@ -34,7 +34,7 @@ the implementation. It is generally good practise to make features as
 context-aware as possible, for example in terms of support for
 multi-site, multi-tenant or multi-language. For example, by moving a
 configurable path from a Solution-wide configuration under
-<sitecore><settings> in the to the Sitecore <site> node in the
+<sitecore><settings> to the Sitecore <site> node in the
 web.config, one can help make a feature site context specific - or by
 changing the value of an Unversioned setting field, one can make a 
 feature context language specific.

--- a/helix/principles/language-support/index.rst
+++ b/helix/principles/language-support/index.rst
@@ -6,7 +6,7 @@ on the business requirements, but it is recommended that you include
 support for multiple languages or cultures in your modules. This not
 only adds the possibility for adding more languages or cultures over
 time, but also encourages good practices such as not hard coding any
-content and letting an editor manage and edit all texts on the website.
+content and letting an editor manage and edit all text on the website.
 
 .. toctree::
     :caption: Topics 

--- a/helix/principles/layout/rendering-parameters.rst
+++ b/helix/principles/layout/rendering-parameters.rst
@@ -11,7 +11,7 @@ template reference any setting items, make sure that the items along
 with their templates reside in the same module (or in a lower layer
 module) as the parameters template itself.
 
-Please, consider carefully what configuration of the rendering belongs
+Please consider carefully what configuration of the rendering belongs
 in the datasource or on the context page, as opposed to the rendering
 parameters. Rendering parameters are generally considered less editor
 friendly than content fields and are often restricted to administrators,

--- a/helix/principles/theming/scripting.rst
+++ b/helix/principles/theming/scripting.rst
@@ -31,10 +31,10 @@ depending on what purpose they serve:
 In order to support this type of separation, the implementation will
 need a mechanism for features to register scripts to be loaded – either
 solution-wide or on the pages where they are used. Since Sitecore does
-not natively provide such a mechanism, your will need to choose the
-approach and provide this in the foundation layer. This can be
+not natively provide such a mechanism, you will need to choose the
+approach and provide this in the Foundation layer. This can be
 accomplished by using either a standard framework, such as require.js,
-or custom logic implemented in a foundation layer module.
+or custom logic implemented in a Foundation layer module.
 
 .. admonition:: Habitat Example
 

--- a/helix/principles/visual-studio/index.rst
+++ b/helix/principles/visual-studio/index.rst
@@ -16,7 +16,7 @@ technical debt.
 
 In large scale implementations, it is therefore often helpful to break
 down your implementation into multiple Visual Studio Solutions – each
-with a logical grouping, for example independent foundation modules,
+with a logical grouping, for example independent Foundation modules,
 cross-project or reusable modules or feature groupings such as Basic
 Website or Commerce features.
 


### PR DESCRIPTION
This is a collection of grammar, spelling, and capitalization fixes in the Patterns, Principles, and Conventions section of the documentation.